### PR TITLE
new features and some bug fix

### DIFF
--- a/lego/CHANGELOG.md
+++ b/lego/CHANGELOG.md
@@ -1,4 +1,24 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
+## 0.2.0
+
+### New Features
+
+- Add `--renew-hook` to automatically restart `Home-Assistant core` when renewing certificate.
+
+### Improvements
+
+- Better check for specific domain certificate, issue each domain severalty.
+- Remove config option `interval` in favor of running in specific time. 
+- Change port for the `http challenge` from `80` to high port `8091` to free port `80` for other services.
+- Change default renew time to `30` days to reduce the renew frequency
+
+### Bug Fix
+
+- Fix command selection done once on addon start.
+
+### Others
+
+- Code cleanup
 
 ## 0.1.3
 

--- a/lego/DOCS.md
+++ b/lego/DOCS.md
@@ -4,7 +4,7 @@ Let's Encrypt client and ACME library written in Go.
 
 ## Installation
 1. Navigate in your Home Assistant frontend to Supervisor -> Add-on Store.
-2. Add the repository via the 3 dots manue > repositories > enter "https://github.com/via-justa/via-justa-home-assistant-addons" > select add
+2. Add the repository via the 3 dots menu > repositories > enter "https://github.com/via-justa/via-justa-home-assistant-addons" > select add
 2. Find the "lego" add-on and click it.
 3. Click on the "INSTALL" button.
 
@@ -20,7 +20,7 @@ email: me@gmail.com
 env_vars:
   - name: HETZNER_API_KEY
     value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-challange: dns
+challenge: dns
 ```
 
 ### Global configuration settings
@@ -34,20 +34,20 @@ can also be wildcard domain (e.g. `*.domain.com`)
 
 Email Let's Encrypt register the certificates to
 
-**Option:** `provider` (required for DNS challange)
+**Option:** `provider` (required for DNS challenge)
 
-Name of the provider for the DNS challange.
+Name of the provider for the DNS challenge.
 List of available providers can be found [here](https://go-acme.github.io/lego/dns/)
 
-**Option:** `env_vars` (required for DNS challange)
+**Option:** `env_vars` (required for DNS challenge)
 
 List of `name` and `value` keys where `name` is the environment variable name and `value` is its value.
 
 A full providers configuration details can be found [here](https://go-acme.github.io/lego/dns/)
 
-**Option:** `challange` (optional)
+**Option:** `challenge` (optional)
 
-What type of challange should be used. Available options are `http` and `dns`
+What type of challenge should be used. Available options are `http` and `dns`
 
 *default: `http`*
 
@@ -55,13 +55,19 @@ What type of challange should be used. Available options are `http` and `dns`
 
 Number of days before the certificate expires to renew it.
 
-*default: `45`*
+*default: `30`*
 
-**Option:** `interval` (optional)
+**Option:** `check_time` (optional)
 
-Interval to check certificate validity.
+Time of day to run the renewal.
 
-*default: `1d`*
+*default: `04:00`*
+
+**Option:** `port` (optional)
+
+Port used by HTTP challenge against
+
+*default: `8091`*
 
 **Option:** `log_level` (optional)
 

--- a/lego/Dockerfile
+++ b/lego/Dockerfile
@@ -15,8 +15,9 @@ RUN apk add --no-cache -t deps git make musl-dev go \
     && apk del deps && rm -r /root/go \
     && chmod +x /usr/local/bin/lego
 
-# Copy root filesystem
-COPY rootfs/run.sh /
+RUN apk add tzdata jq
+
+COPY rootfs /
 
 RUN chmod a+x /run.sh
 

--- a/lego/README.md
+++ b/lego/README.md
@@ -14,8 +14,8 @@
 
 Let's Encrypt client and ACME library written in Go.
 
-Supports both HTTP and DNS-01 challanges with a long list of providers
+Supports both HTTP and DNS-01 challenges with a long list of providers
 
 ## Lego vs The built-in Let's Encrypt addon
 
-While the built-in [Let's Encrypt addon](https://github.com/home-assistant/addons/tree/master/letsencrypt) is good and well for HTTP challange, when it comes to DNS-01 challange it supports only very limitaed number of DNS providers (19 as of end of 2021) while [Lego](https://github.com/go-acme/lego) supports 98(!!) different DNS providers. If that's not enough to convince you, the built-in addon does not "watch" the certificate and renew it automatically while this addon does.
+While the built-in [Let's Encrypt addon](https://github.com/home-assistant/addons/tree/master/letsencrypt) is good and well for HTTP challenge, when it comes to DNS-01 challenge it supports only very limited number of DNS providers (19 as of end of 2021) while [Lego](https://github.com/go-acme/lego) supports 98(!!) different DNS providers. If that's not enough to convince you, the built-in addon does not "watch" the certificate and renew it automatically while this addon does.

--- a/lego/config.yaml
+++ b/lego/config.yaml
@@ -1,10 +1,13 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Lego
-version: "0.1.3"
+version: "0.2.0"
 slug: lego
 description: Let's Encrypt client and ACME library written in Go.
 url: "https://github.com/via-justa/go-acme-lego-addon/tree/main/lego"
-image: ghcr.io/via-justa/{arch}-lego
+# image: ghcr.io/via-justa/{arch}-lego
+hassio_api: true
+hassio_role: homeassistant 
+homeassistant_api: true
 map:
   - ssl:rw
   - share
@@ -14,11 +17,11 @@ arch:
   - aarch64
   - amd64
   - i386
-ingress: true
 options:
   provider: ""
   domains: []
   email: ""
+  check_time: "04:00"
   env_vars:
     - name: ""
       value: ""
@@ -27,14 +30,15 @@ schema:
   domains: 
     - str
   email: str
+  check_time: match(^\d\d\:\d\d$)
   env_vars:
     - name: match(^([A-Z0-9_])+$)
       value: str
-  challange: list(dns|http)?
+  challenge: list(dns|http)?
   renew_threshold: int?
-  interval: str?
+  port: int?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
 ports:
-  80/tcp: null
+  8091/tcp: null
 ports_description:
-  80/tcp: Only needed for http challenge
+  8091/tcp: Only needed for http challenge (if mapping to different port `port` must be configured)

--- a/lego/rootfs/functions.sh
+++ b/lego/rootfs/functions.sh
@@ -1,0 +1,45 @@
+
+# Call: config <config key> <default value>
+config() {
+    if bashio::config.has_value "$1"; then
+        echo $(bashio::config "$1")
+    else
+        echo $2
+    fi
+}
+
+# Call: env_export <key> <value>
+env_export() {
+    len=$((${#2} - 3))
+    str=""
+	for i in {1..${len}}; do str=${str}*; done
+    sanitized_value=${str}$(echo ${2} | grep -o ...$)
+
+    bashio::log.info "Setting ${1} to ${sanitized_value}"
+    export "${1}=${2}"
+}
+
+get_tz() {
+    curl -sSL -H "Authorization: Bearer $SUPERVISOR_TOKEN" http://supervisor/info | jq -r '.data.timezone'
+}
+
+restart_ha() {
+    curl -X POST -sSL -H "Authorization: Bearer $SUPERVISOR_TOKEN" http://supervisor/core/restart
+}
+
+execute() {
+    for domain in $(bashio::config 'domains'); do
+        bashio::log.debug "checking domain ${domain}"
+        args="${1} --domains ${domain}"
+        # select command
+        if [[ -f "${CERT_PATH}/certificates/${domain}.crt" ]]; then
+            bashio::log.debug "running command: lego ${1} run"
+            bashio::log.info "Certificate for domain ${domain} not found, issuing"
+            lego ${args} run
+        else
+            bashio::log.debug "running command: lego ${1} renew --days ${renew_threshold} --renew-hook restart_ha"
+            bashio::log.info "Certificate for domain ${domain} found, checking if renew needed"
+            lego ${args} renew --days ${renew_threshold} --renew-hook restart_ha
+        fi
+    done
+}

--- a/lego/rootfs/run.sh
+++ b/lego/rootfs/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/with-contenv bashio
 CONFIG_PATH=/data/options.json
 
+source /functions.sh
+
 CERT_PATH=/ssl/lego
 mkdir -p ${CERT_PATH}
 mkdir -p ${CERT_PATH}/certificates
@@ -9,7 +11,6 @@ declare cmd
 declare args
 declare challange
 declare renew_threshold
-declare interval
 declare log_level
 
 ## defaults
@@ -18,58 +19,37 @@ if bashio::config.has_value 'log_level'; then
     bashio::log.level $(bashio::config 'log_level')
 fi
 
+# Set timezone
+cp /usr/share/zoneinfo/$(get_tz) /etc/localtime
+bashio::log.debug "config::timezone $(get_tz)"
+
 # Set challange
-if bashio::config.has_value 'challange'; then
-    challange=$(bashio::config 'challange')
-else
-    challange=http
-fi
+challange=$(config challange "http")
 bashio::log.debug "config::challange ${challange}"
 
 # Set renew_threshold
-if bashio::config.has_value 'renew_threshold'; then
-    renew_threshold=$(bashio::config 'renew_threshold')
-else
-    renew_threshold=45
-fi
+renew_threshold=$(config renew_threshold "30")
 bashio::log.debug "config::renew_threshold ${renew_threshold}"
 
-# Set interval
-if bashio::config.has_value 'interval'; then
-    interval=$(bashio::config 'interval')
-else
-    interval=1d
-fi
-bashio::log.debug "config::interval ${interval}"
+# Set port
+port=$(config port 8091)
+bashio::log.debug "config::port ${port}"
 
 bashio::log.debug "config::provider $(bashio::config 'provider')"
 bashio::log.debug "config::domains $(bashio::config 'domains')"
 bashio::log.debug "config::email $(bashio::config 'email')"
 bashio::log.debug "config::env_vars $(bashio::config 'env_vars')"
 
-
 # Export env vars
 for var in $(bashio::config 'env_vars|keys'); do
     name=$(bashio::config "env_vars[${var}].name")
     value=$(bashio::config "env_vars[${var}].value")
 
-    # sanitize env value
-    len=$((${#value} - 3))
-    str=""
-	for i in {1..$1}; do str=${str}*; done
-    sanitized_value=${str}$(echo ${value} | grep -o ...$)
-
-    bashio::log.info "Setting ${name} to ${sanitized_value}"
-    export "${name}=${value}"
+    env_export ${name} ${value}
 done
 
-args="--accept-tos"
-
-# Add email argument. Needed by both http and dns challanges
-args="${args} --email $(bashio::config 'email')"
-
-# Add output folder argument
-args="${args} --path ${CERT_PATH}"
+# set default common arguments
+args="--accept-tos --email $(bashio::config 'email') --path ${CERT_PATH}"
 
 # Create domains list. Needed by both http and dns challanges
 for domain in $(bashio::config 'domains'); do
@@ -81,21 +61,14 @@ done
 if [ "${challange}" == "dns" ]; then
     args="${args} --dns $(bashio::config 'provider')"
 else
-    args="${args} --http --http.port :80"
-fi
-
-# sellect command
-if [[ -z `ls -A "${CERT_PATH}/certificates"` ]]; then
-    cmd="run"
-else
-    cmd="renew --days ${renew_threshold}"
+    args="${args} --http --http.port :${port}"
 fi
 
 # create/renew certificate
 while true
 do
-    bashio::log.debug "running command: /lego ${args} ${cmd}"
-    lego ${args} ${cmd}
-    bashio::log.info "sleeping for ${interval}"
-	sleep ${interval}
+    if [ "$(date +"%H:%M")" == "$(bashio::config 'check_time')" ]; then
+        execute ${args}
+    fi
+    sleep 60
 done


### PR DESCRIPTION
### New Features

- Add `--renew-hook` to automatically restart `Home-Assistant core` when renewing certificate.

### Improvements

- Better check for specific domain certificate, issue each domain severalty.
- Remove config option `interval` in favor of running in specific time. 
- Change port for the `http challenge` from `80` to high port `8091` to free port `80` for other services.
- Change default renew time to `30` days to reduce the renew frequency

### Bug Fix

- Fix command selection done once on addon start.

### Others

- Code cleanup