### PR TITLE
Multiple SANs in a single certificate

### DIFF
--- a/lego/DOCS.md
+++ b/lego/DOCS.md
@@ -63,6 +63,7 @@ challenge: dns
 
 List of domains to generate certificate for.
 can also be wildcard domain (e.g. `*.domain.com`)
+You can create a certificate with multiple SANs by comma-separating them on a single line (e.g. `*.domain.com,host.domain.com`)
 
 **Option:** `email` (required)
 

--- a/lego/rootfs/run.sh
+++ b/lego/rootfs/run.sh
@@ -56,7 +56,7 @@ args="--accept-tos --email $(bashio::config 'email') --path ${CERT_PATH}"
 
 # Log domain list
 for domain in $(bashio::config 'domains'); do
-    sans=(${$domain//,/ })
+    sans=(${domain//,/ })
     bashio::log.info "Monitoring certificate for ${sans[0]}"
 done
 
@@ -69,7 +69,7 @@ fi
 
 # create new certificates
 for domain in $(bashio::config 'domains'); do
-    sans=(${$domain//,/ })
+    sans=(${domain//,/ })
     bashio::log.debug "Checking for certificate ${CERT_PATH}/certificates/${sans[0]}.crt existence "
     if [[ ! -f "${CERT_PATH}/certificates/${sans[0]}.crt" ]]; then
         bashio::log.debug "running command: lego ${args} run"


### PR DESCRIPTION
This change allows you do something like this:

```yaml
domains:
  - '*.home.somedomain.com,server.somedomain.com'
  - '*.dns.somedomain.com,dns.somedomain.com'
````
  
which will generate two certificates containing 2 SANs each. The subject name (and file name) of each will be the first domain in the list, as per Lego's default behavior.